### PR TITLE
Phase 1: フレーム抽出と初期スコアリング基盤を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ NAS 上の写真や動画からハイライト動画を自動生成します。
 - **LAN 向け Web ビューア** — ホバーでプレビュー、クリックでフルスクリーン再生
 - **定期実行** — cron ベースで自動実行（デフォルト: 毎日午前 2 時）
 - **既処理データをスキップ** — SQLite で生成済み内容を管理
+- **スコアリング基盤** — `ffmpeg` とローカル処理で動画フレームの focus / change / total を算出
 
 ---
 
@@ -59,6 +60,9 @@ bun run generate
 # 指定した画像一覧だけでハイライトを生成
 bun run generate --input-list /path/to/input-files.txt
 
+# 動画フレームの初期スコアを JSON で確認
+bun src/cli/run-highlight.ts /path/to/input.mp4 --fps 4
+
 # 直近の生成結果を通知
 bun run notify
 
@@ -86,6 +90,10 @@ src/
 ├── pipeline.ts       # メインのオーケストレーション
 ├── scanner/
 │   └── grouper.ts    # NAS を走査し、画像・動画を日付/フォルダでグループ化
+├── core/             # スコア正規化・集計
+├── analyzers/        # focus / change などの analyzer
+├── infra/            # ffmpeg など外部ツール連携
+├── types/            # scoring 用の型定義
 ├── scorer/
 │   └── imageScore.ts # シャープネス + 明るさのスコアリング
 ├── generator/

--- a/src/analyzers/change.ts
+++ b/src/analyzers/change.ts
@@ -1,0 +1,48 @@
+import sharp from 'sharp'
+
+async function loadComparableFrame(imagePath: string, width = 160) {
+  const { data, info } = await sharp(imagePath)
+    .grayscale()
+    .resize({ width, withoutEnlargement: true })
+    .raw()
+    .toBuffer({ resolveWithObject: true })
+
+  return {
+    data,
+    height: info.height,
+    width: info.width,
+  }
+}
+
+export async function calculateFrameDiff(previousPath: string, currentPath: string): Promise<number> {
+  const previous = await loadComparableFrame(previousPath)
+  const current = await loadComparableFrame(currentPath)
+
+  const width = Math.min(previous.width, current.width)
+  const height = Math.min(previous.height, current.height)
+
+  if (width === 0 || height === 0) return 0
+
+  let diffSum = 0
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const previousIndex = y * previous.width + x
+      const currentIndex = y * current.width + x
+      diffSum += Math.abs(previous.data[previousIndex] - current.data[currentIndex])
+    }
+  }
+
+  return diffSum / (width * height * 255)
+}
+
+export function combineChangeScore({
+  expressionDelta = 0,
+  frameDiff,
+  sceneChange,
+}: {
+  expressionDelta?: number
+  frameDiff: number
+  sceneChange: number
+}) {
+  return (frameDiff * 0.5) + (sceneChange * 0.3) + (expressionDelta * 0.2)
+}

--- a/src/analyzers/focus.ts
+++ b/src/analyzers/focus.ts
@@ -1,0 +1,33 @@
+import sharp from 'sharp'
+
+const LAPLACIAN_KERNEL = {
+  width: 3,
+  height: 3,
+  kernel: [
+    0, 1, 0,
+    1, -4, 1,
+    0, 1, 0,
+  ],
+}
+
+export async function calculateLaplacianVariance(imagePath: string): Promise<number> {
+  const { data } = await sharp(imagePath)
+    .grayscale()
+    .convolve(LAPLACIAN_KERNEL)
+    .raw()
+    .toBuffer({ resolveWithObject: true })
+
+  if (data.length === 0) return 0
+
+  let sum = 0
+  for (const value of data) sum += value
+  const mean = sum / data.length
+
+  let varianceSum = 0
+  for (const value of data) {
+    const diff = value - mean
+    varianceSum += diff * diff
+  }
+
+  return varianceSum / data.length
+}

--- a/src/cli/run-highlight.ts
+++ b/src/cli/run-highlight.ts
@@ -1,0 +1,35 @@
+import { mkdtempSync } from 'fs'
+import os from 'os'
+import path from 'path'
+import { rm } from 'fs/promises'
+import { extractVideoFrames } from '../infra/ffmpeg.js'
+import { scoreVideoFrames } from '../core/scoring.js'
+
+const args = process.argv.slice(2)
+const mediaPath = args[0]
+const fpsIndex = args.indexOf('--fps')
+const fps = fpsIndex >= 0 ? Number(args[fpsIndex + 1]) : 4
+
+if (!mediaPath) {
+  throw new Error('Usage: bun src/cli/run-highlight.ts /path/to/video.mp4 [--fps 4]')
+}
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), 'nas-photo-highlight-score-'))
+
+try {
+  const frames = await extractVideoFrames({
+    fps,
+    inputPath: mediaPath,
+    outputDir: tempDir,
+  })
+  const scores = await scoreVideoFrames(frames)
+
+  console.log(JSON.stringify({
+    fps,
+    frameCount: scores.length,
+    mediaPath,
+    scores,
+  }, null, 2))
+} finally {
+  await rm(tempDir, { recursive: true, force: true })
+}

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -1,0 +1,40 @@
+export function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const rank = clamp(p, 0, 1) * (sorted.length - 1)
+  const lower = Math.floor(rank)
+  const upper = Math.ceil(rank)
+
+  if (lower === upper) return sorted[lower]
+
+  const weight = rank - lower
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight
+}
+
+export function normalizeByPercentile(
+  values: number[],
+  {
+    lowerPercentile = 0.1,
+    upperPercentile = 0.9,
+  }: {
+    lowerPercentile?: number
+    upperPercentile?: number
+  } = {}
+): number[] {
+  if (values.length === 0) return []
+
+  const low = percentile(values, lowerPercentile)
+  const high = percentile(values, upperPercentile)
+  const range = high - low
+
+  if (range <= 0) {
+    return values.map((value) => value > low ? 1 : 0)
+  }
+
+  return values.map((value) => clamp((value - low) / range, 0, 1))
+}

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -1,0 +1,59 @@
+import { calculateFrameDiff, combineChangeScore } from '../analyzers/change.js'
+import { calculateLaplacianVariance } from '../analyzers/focus.js'
+import { normalizeByPercentile } from './normalize.js'
+import type { SampledFrame } from '../types/media.js'
+import type { FrameScore } from '../types/score.js'
+
+export function calculateTotalScore({
+  expression,
+  change,
+  focus,
+  bonus,
+}: {
+  expression: number
+  change: number
+  focus: number
+  bonus: number
+}) {
+  return (expression * 0.35) + (change * 0.30) + (focus * 0.25) + (bonus * 0.10)
+}
+
+export async function scoreVideoFrames(frames: SampledFrame[]): Promise<FrameScore[]> {
+  if (frames.length === 0) return []
+
+  const laplacianValues = await Promise.all(frames.map((frame) => calculateLaplacianVariance(frame.path)))
+  const focusScores = normalizeByPercentile(laplacianValues)
+
+  const frameDiffValues = await Promise.all(frames.map(async (frame, index) => {
+    if (index === 0) return 0
+    return calculateFrameDiff(frames[index - 1].path, frame.path)
+  }))
+  const normalizedFrameDiffs = normalizeByPercentile(frameDiffValues)
+  const normalizedSceneChanges = normalizeByPercentile(frames.map((frame) => frame.sceneChange))
+
+  return frames.map((frame, index) => {
+    const expression = 0
+    const bonus = 0
+    const change = combineChangeScore({
+      frameDiff: normalizedFrameDiffs[index] ?? 0,
+      sceneChange: normalizedSceneChanges[index] ?? 0,
+      expressionDelta: 0,
+    })
+    const focus = focusScores[index] ?? 0
+
+    return {
+      path: frame.path,
+      time: frame.time,
+      expression,
+      change,
+      focus,
+      bonus,
+      total: calculateTotalScore({ expression, change, focus, bonus }),
+      meta: {
+        frameDiff: frameDiffValues[index] ?? 0,
+        laplacianVar: laplacianValues[index] ?? 0,
+        sceneChange: frame.sceneChange,
+      },
+    }
+  })
+}

--- a/src/infra/ffmpeg.ts
+++ b/src/infra/ffmpeg.ts
@@ -1,0 +1,56 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { readdir } from 'fs/promises'
+import path from 'path'
+import type { ExtractVideoFramesOptions, SampledFrame } from '../types/media.js'
+
+const execFileAsync = promisify(execFile)
+
+export function buildFrameExtractionArgs({
+  fps,
+  inputPath,
+  outputDir,
+}: ExtractVideoFramesOptions) {
+  return [
+    '-hide_banner',
+    '-loglevel',
+    'info',
+    '-i',
+    inputPath,
+    '-vf',
+    `fps=${fps},scale=640:-1:force_original_aspect_ratio=decrease,showinfo`,
+    '-vsync',
+    'vfr',
+    path.join(outputDir, 'frame-%06d.jpg'),
+  ]
+}
+
+export function parseShowinfoLine(line: string) {
+  const ptsTimeMatch = line.match(/pts_time:([0-9.]+)/)
+  if (!ptsTimeMatch) return null
+
+  const sceneScoreMatch = line.match(/scene_score[:=]([0-9.]+)/)
+  return {
+    sceneChange: sceneScoreMatch ? Number(sceneScoreMatch[1]) : 0,
+    time: Number(ptsTimeMatch[1]),
+  }
+}
+
+export async function extractVideoFrames(options: ExtractVideoFramesOptions): Promise<SampledFrame[]> {
+  const args = buildFrameExtractionArgs(options)
+  const { stderr } = await execFileAsync('ffmpeg', args)
+  const frameMetadata = stderr
+    .split('\n')
+    .map(parseShowinfoLine)
+    .filter((line): line is { sceneChange: number, time: number } => line !== null)
+
+  const frameFiles = (await readdir(options.outputDir))
+    .filter((file) => file.endsWith('.jpg'))
+    .sort((a, b) => a.localeCompare(b))
+
+  return frameFiles.map((file, index) => ({
+    path: path.join(options.outputDir, file),
+    sceneChange: frameMetadata[index]?.sceneChange ?? 0,
+    time: frameMetadata[index]?.time ?? index / options.fps,
+  }))
+}

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -1,0 +1,11 @@
+export interface SampledFrame {
+  path: string
+  time: number
+  sceneChange: number
+}
+
+export interface ExtractVideoFramesOptions {
+  fps: number
+  inputPath: string
+  outputDir: string
+}

--- a/src/types/score.ts
+++ b/src/types/score.ts
@@ -1,0 +1,16 @@
+export interface FrameScoreMeta {
+  frameDiff: number
+  laplacianVar: number
+  sceneChange: number
+}
+
+export interface FrameScore {
+  path: string
+  time: number
+  expression: number
+  change: number
+  focus: number
+  bonus: number
+  total: number
+  meta: FrameScoreMeta
+}

--- a/test/change.test.ts
+++ b/test/change.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import os from 'os'
+import path from 'path'
+import sharp from 'sharp'
+import { calculateFrameDiff, combineChangeScore } from '../src/analyzers/change.js'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeDir() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'nas-photo-highlight-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+async function writeSolidImage(filePath: string, value: number) {
+  await sharp({
+    create: {
+      width: 32,
+      height: 32,
+      channels: 3,
+      background: {
+        r: value,
+        g: value,
+        b: value,
+      },
+    },
+  }).png().toFile(filePath)
+}
+
+describe('calculateFrameDiff', () => {
+  it('見た目が大きく違うフレームほど差分が大きい', async () => {
+    const dir = makeDir()
+    const black = path.join(dir, 'black.png')
+    const white = path.join(dir, 'white.png')
+
+    await writeSolidImage(black, 0)
+    await writeSolidImage(white, 255)
+
+    expect(await calculateFrameDiff(black, white)).toBe(1)
+  })
+})
+
+describe('combineChangeScore', () => {
+  it('frame diff と scene change と expression delta を重み付き合成する', () => {
+    expect(combineChangeScore({
+      frameDiff: 1,
+      sceneChange: 0.5,
+      expressionDelta: 0.25,
+    })).toBeCloseTo(0.7, 5)
+  })
+})

--- a/test/ffmpegInfra.test.ts
+++ b/test/ffmpegInfra.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test'
+import { buildFrameExtractionArgs, parseShowinfoLine } from '../src/infra/ffmpeg.js'
+
+describe('buildFrameExtractionArgs', () => {
+  it('fps 抽出用の ffmpeg 引数を組み立てる', () => {
+    expect(buildFrameExtractionArgs({
+      fps: 4,
+      inputPath: '/tmp/input.mp4',
+      outputDir: '/tmp/out',
+    })).toEqual([
+      '-hide_banner',
+      '-loglevel',
+      'info',
+      '-i',
+      '/tmp/input.mp4',
+      '-vf',
+      'fps=4,scale=640:-1:force_original_aspect_ratio=decrease,showinfo',
+      '-vsync',
+      'vfr',
+      '/tmp/out/frame-%06d.jpg',
+    ])
+  })
+})
+
+describe('parseShowinfoLine', () => {
+  it('showinfo 行から pts_time を読む', () => {
+    expect(parseShowinfoLine('[Parsed_showinfo_0 @ 0x0] n:   1 pts: 3000 pts_time:0.750')).toEqual({
+      time: 0.75,
+      sceneChange: 0,
+    })
+  })
+})

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test'
+import { normalizeByPercentile, percentile } from '../src/core/normalize.js'
+
+describe('percentile', () => {
+  it('線形補間で percentile を計算する', () => {
+    expect(percentile([0, 10, 20, 30], 0.5)).toBe(15)
+  })
+})
+
+describe('normalizeByPercentile', () => {
+  it('p10-p90 を基準に 0-1 正規化する', () => {
+    expect(normalizeByPercentile([0, 10, 20, 30, 40])).toEqual([0, 0.1875, 0.5, 0.8125, 1])
+  })
+})

--- a/test/scoring.test.ts
+++ b/test/scoring.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import os from 'os'
+import path from 'path'
+import sharp from 'sharp'
+import { calculateTotalScore, scoreVideoFrames } from '../src/core/scoring.js'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeDir() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'nas-photo-highlight-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+async function writeGradient(filePath: string, start: number, end: number) {
+  const width = 64
+  const height = 64
+  const pixels = new Uint8Array(width * height * 3)
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const value = Math.round(start + ((end - start) * x / (width - 1)))
+      const offset = (y * width + x) * 3
+      pixels[offset] = value
+      pixels[offset + 1] = value
+      pixels[offset + 2] = value
+    }
+  }
+
+  await sharp(pixels, {
+    raw: {
+      width,
+      height,
+      channels: 3,
+    },
+  }).png().toFile(filePath)
+}
+
+describe('calculateTotalScore', () => {
+  it('親 issue の初期重みで総合スコアを計算する', () => {
+    expect(calculateTotalScore({
+      expression: 0.6,
+      change: 0.4,
+      focus: 0.2,
+      bonus: 0.1,
+    })).toBeCloseTo(0.39, 5)
+  })
+})
+
+describe('scoreVideoFrames', () => {
+  it('フレーム列に focus/change/total を付与する', async () => {
+    const dir = makeDir()
+    const a = path.join(dir, 'a.png')
+    const b = path.join(dir, 'b.png')
+
+    await writeGradient(a, 0, 255)
+    await writeGradient(b, 255, 0)
+
+    const scores = await scoreVideoFrames([
+      { path: a, time: 0, sceneChange: 0 },
+      { path: b, time: 0.25, sceneChange: 0.7 },
+    ])
+
+    expect(scores).toHaveLength(2)
+    expect(scores[0]?.time).toBe(0)
+    expect(scores[1]?.change).toBeGreaterThan(scores[0]?.change ?? 0)
+    expect(scores[0]?.focus).toBeGreaterThanOrEqual(0)
+    expect(scores[1]?.total).toBeGreaterThanOrEqual(0)
+  })
+})


### PR DESCRIPTION
## 概要
- ffmpeg を使った動画フレーム抽出の基盤を追加
- focus / change / total の初期スコアリングをローカル実行で計算する基盤を追加
- 正規化、ffmpeg 連携、CLI、README、テストを追加

## 確認
- bun test
- bun run lint

## 補足
- 親 Issue: #4
- 対応するサブイシュー: #5