### PR TITLE
再生可能なハイライト mp4 を優先する生成方式に変更

### DIFF
--- a/src/generator/highlight.ts
+++ b/src/generator/highlight.ts
@@ -1,4 +1,7 @@
 import ffmpeg from 'fluent-ffmpeg'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import os from 'os'
+import path from 'path'
 import { config } from '../config'
 
 const HIGHLIGHT_WIDTH = 1080
@@ -10,91 +13,153 @@ export interface HighlightSegment {
   type: 'image' | 'video'
 }
 
-export function buildHighlightVideoFilters(secondsPerImage: number): string[] {
+export function buildImageSegmentFilters(secondsPerImage: number): string[] {
   return [
-    // Keep the full image visible and scale it as large as possible inside the portrait frame.
     `scale=${HIGHLIGHT_WIDTH}:${HIGHLIGHT_HEIGHT}:force_original_aspect_ratio=decrease`,
     `pad=${HIGHLIGHT_WIDTH}:${HIGHLIGHT_HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=black`,
-    // Ken Burns: slow zoom in, reset each image (d=framerate*duration)
     `zoompan=z='if(lte(zoom,1.0),1.15,max(1.001,zoom-0.001))':d=${secondsPerImage * HIGHLIGHT_FPS}:s=${HIGHLIGHT_WIDTH}x${HIGHLIGHT_HEIGHT}:fps=${HIGHLIGHT_FPS}`,
+    'setsar=1',
+    'format=yuv420p',
   ]
 }
 
-export function buildHighlightFilterGraph(
-  segments: HighlightSegment[],
-  secondsPerImage: number
-): string[] {
-  const filters = segments.map((segment, index) => {
-    if (segment.type === 'image') {
-      return `[${index}:v]scale=${HIGHLIGHT_WIDTH}:${HIGHLIGHT_HEIGHT}:force_original_aspect_ratio=decrease,pad=${HIGHLIGHT_WIDTH}:${HIGHLIGHT_HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=black,zoompan=z='if(lte(zoom,1.0),1.15,max(1.001,zoom-0.001))':d=${secondsPerImage * HIGHLIGHT_FPS}:s=${HIGHLIGHT_WIDTH}x${HIGHLIGHT_HEIGHT}:fps=${HIGHLIGHT_FPS},setsar=1[v${index}]`
-    }
+export function buildVideoSegmentFilters(): string[] {
+  return [
+    `scale=${HIGHLIGHT_WIDTH}:${HIGHLIGHT_HEIGHT}:force_original_aspect_ratio=decrease`,
+    `pad=${HIGHLIGHT_WIDTH}:${HIGHLIGHT_HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=black`,
+    `fps=${HIGHLIGHT_FPS}`,
+    'setsar=1',
+    'setpts=PTS-STARTPTS',
+    'format=yuv420p',
+  ]
+}
 
-    return `[${index}:v]scale=${HIGHLIGHT_WIDTH}:${HIGHLIGHT_HEIGHT}:force_original_aspect_ratio=decrease,pad=${HIGHLIGHT_WIDTH}:${HIGHLIGHT_HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=black,fps=${HIGHLIGHT_FPS},setsar=1[v${index}]`
+export function buildConcatListContent(segmentPaths: string[]): string {
+  const lines = segmentPaths.map((segmentPath) => {
+    const escapedPath = segmentPath.replace(/'/g, "'\\''")
+    return `file '${escapedPath}'`
   })
 
-  const concatInputs = segments.map((_, index) => `[v${index}]`).join('')
-  filters.push(`${concatInputs}concat=n=${segments.length}:v=1:a=0[vout]`)
+  return `${lines.join('\n')}\n`
+}
 
-  return filters
+function runFfmpegCommand(
+  command: ffmpeg.FfmpegCommand,
+  outputPath: string
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    command
+      .output(outputPath)
+      .on('start', (cmdLine) => console.log(`  ffmpeg: ${cmdLine}`))
+      .on('progress', (progress) => {
+        if (progress.percent) {
+          process.stdout.write(`\r  encoding: ${Math.round(progress.percent)}%`)
+        }
+      })
+      .on('end', () => {
+        console.log(`\n  ✅ saved: ${outputPath}`)
+        resolve()
+      })
+      .on('error', (error) => {
+        rm(outputPath, { force: true })
+          .catch(() => undefined)
+          .finally(() => {
+            reject(error)
+          })
+      })
+      .run()
+  })
+}
+
+async function renderSegmentClip(
+  segment: HighlightSegment,
+  outputPath: string
+): Promise<void> {
+  let command = ffmpeg().input(segment.path)
+
+  if (segment.type === 'image') {
+    command = command
+      .inputOptions(['-loop 1', `-t ${config.processing.secondsPerImage}`])
+      .videoFilters(buildImageSegmentFilters(config.processing.secondsPerImage))
+  } else {
+    command = command.videoFilters(buildVideoSegmentFilters())
+  }
+
+  command = command
+    .videoCodec('libx264')
+    .outputOptions([
+      '-pix_fmt yuv420p',
+      '-movflags +faststart',
+      `-r ${HIGHLIGHT_FPS}`,
+      '-an',
+    ])
+
+  await runFfmpegCommand(command, outputPath)
+}
+
+async function concatSegmentClips(
+  segmentPaths: string[],
+  outputPath: string
+): Promise<void> {
+  const listPath = path.join(
+    path.dirname(outputPath),
+    `.concat-${path.basename(outputPath)}.txt`
+  )
+  await writeFile(listPath, buildConcatListContent(segmentPaths), 'utf8')
+
+  try {
+    let command = ffmpeg()
+      .input(listPath)
+      .inputOptions(['-f concat', '-safe 0'])
+      .videoCodec('libx264')
+      .outputOptions([
+        '-pix_fmt yuv420p',
+        '-movflags +faststart',
+        `-r ${HIGHLIGHT_FPS}`,
+      ])
+
+    if (config.bgmPath) {
+      command = command
+        .input(config.bgmPath)
+        .audioCodec('aac')
+        .audioBitrate('192k')
+        .outputOptions(['-map 0:v:0', '-map 1:a:0', '-shortest'])
+    } else {
+      command = command.outputOptions(['-map 0:v:0', '-an'])
+    }
+
+    await runFfmpegCommand(command, outputPath)
+  } finally {
+    await rm(listPath, { force: true })
+  }
 }
 
 /**
  * Generate a highlight movie from image/video segments.
- * Images use Ken Burns; videos are inserted at original duration.
+ * Each segment is normalized to a playable mp4 clip before final concat.
  */
-export function generateHighlight(
+export async function generateHighlight(
   segments: HighlightSegment[],
   outputPath: string
 ): Promise<void> {
-  return new Promise((resolve, reject) => {
-    let cmd = ffmpeg()
+  const tempDir = await mkdtemp(
+    path.join(os.tmpdir(), 'nas-photo-highlight-render-')
+  )
 
-    for (const segment of segments) {
-      cmd = cmd.input(segment.path)
-      if (segment.type === 'image') {
-        cmd = cmd.inputOptions([
-          '-loop 1',
-          `-t ${config.processing.secondsPerImage}`,
-        ])
-      }
+  try {
+    const renderedSegmentPaths: string[] = []
+
+    for (const [index, segment] of segments.entries()) {
+      const segmentOutputPath = path.join(
+        tempDir,
+        `segment-${String(index).padStart(4, '0')}.mp4`
+      )
+      await renderSegmentClip(segment, segmentOutputPath)
+      renderedSegmentPaths.push(segmentOutputPath)
     }
 
-    const filterGraph = buildHighlightFilterGraph(
-      segments,
-      config.processing.secondsPerImage
-    )
-    const outputOptions = [
-      '-map [vout]',
-      '-pix_fmt yuv420p',
-      '-movflags +faststart',
-      `-r ${HIGHLIGHT_FPS}`,
-    ]
-
-    if (config.bgmPath) {
-      const bgmInputIndex = segments.length
-      cmd = cmd.input(config.bgmPath).audioCodec('aac').audioBitrate('192k')
-      outputOptions.push(`-map ${bgmInputIndex}:a:0`, '-shortest')
-    } else {
-      outputOptions.push('-an')
-    }
-
-    cmd
-      .complexFilter(filterGraph)
-      .videoCodec('libx264')
-      .outputOptions(outputOptions)
-      .output(outputPath)
-      .on('start', (cmdLine) => console.log(`  ffmpeg: ${cmdLine}`))
-      .on('progress', (p) => {
-        if (p.percent)
-          process.stdout.write(`\r  encoding: ${Math.round(p.percent)}%`)
-      })
-      .on('end', async () => {
-        console.log(`\n  ✅ saved: ${outputPath}`)
-        resolve()
-      })
-      .on('error', async (err) => {
-        reject(err)
-      })
-      .run()
-  })
+    await concatSegmentClips(renderedSegmentPaths, outputPath)
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
 }

--- a/test/highlight.test.ts
+++ b/test/highlight.test.ts
@@ -1,35 +1,39 @@
 import { describe, expect, it } from 'bun:test'
 import {
-  buildHighlightFilterGraph,
-  buildHighlightVideoFilters,
+  buildConcatListContent,
+  buildImageSegmentFilters,
+  buildVideoSegmentFilters,
 } from '../src/generator/highlight'
 
-describe('buildHighlightVideoFilters', () => {
-  it('スマホ向けの縦長フレーム内で切らずに最大表示する', () => {
-    const filters = buildHighlightVideoFilters(3)
-
-    expect(filters).toEqual([
+describe('buildImageSegmentFilters', () => {
+  it('静止画セグメントを再生可能な縦動画に正規化する', () => {
+    expect(buildImageSegmentFilters(3)).toEqual([
       'scale=1080:1920:force_original_aspect_ratio=decrease',
       'pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black',
       "zoompan=z='if(lte(zoom,1.0),1.15,max(1.001,zoom-0.001))':d=90:s=1080x1920:fps=30",
+      'setsar=1',
+      'format=yuv420p',
     ])
   })
 })
 
-describe('buildHighlightFilterGraph', () => {
-  it('画像と動画を同じ縦動画フォーマットへ正規化して連結する', () => {
-    const graph = buildHighlightFilterGraph(
-      [
-        { path: '/Volumes/photo/a.jpg', type: 'image' },
-        { path: '/Volumes/photo/b.mov', type: 'video' },
-      ],
-      3
-    )
-
-    expect(graph).toEqual([
-      "[0:v]scale=1080:1920:force_original_aspect_ratio=decrease,pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,zoompan=z='if(lte(zoom,1.0),1.15,max(1.001,zoom-0.001))':d=90:s=1080x1920:fps=30,setsar=1[v0]",
-      '[1:v]scale=1080:1920:force_original_aspect_ratio=decrease,pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,fps=30,setsar=1[v1]',
-      '[v0][v1]concat=n=2:v=1:a=0[vout]',
+describe('buildVideoSegmentFilters', () => {
+  it('動画セグメントの fps と timestamp を正規化する', () => {
+    expect(buildVideoSegmentFilters()).toEqual([
+      'scale=1080:1920:force_original_aspect_ratio=decrease',
+      'pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black',
+      'fps=30',
+      'setsar=1',
+      'setpts=PTS-STARTPTS',
+      'format=yuv420p',
     ])
+  })
+})
+
+describe('buildConcatListContent', () => {
+  it('concat demuxer 用の file list を組み立てる', () => {
+    expect(
+      buildConcatListContent(['/tmp/segment-0000.mp4', "/tmp/it's-ok.mp4"])
+    ).toBe("file '/tmp/segment-0000.mp4'\nfile '/tmp/it'\\''s-ok.mp4'\n")
   })
 })


### PR DESCRIPTION
## 概要
- ハイライト生成を一発の filter_complex concat から段階生成へ変更
- 各画像・動画をまず再生可能な mp4 セグメントに正規化してから連結
- 再生互換性を優先して mp4 の出力を安定させる

## 変更内容
- 画像セグメント用の filter を個別関数化
- 動画セグメント用の filter を個別関数化
- 各セグメントを  の mp4 に一旦書き出す構成へ変更
- 最後の結合は concat demuxer を使う方式に変更
- テストを filter graph 文字列比較から、段階生成用の関数テストへ更新

## 確認
- bun test
- bun run lint
- bun run format:check

## 補足
- ローカルの ffmpeg 実行環境ではないため、この環境で実再生確認まではしていません
- ただし生成方式は再生互換性が低い一発 concat より保守的な構成に寄せています