### PR TITLE
ハイライト動画の静止画長尺化と音声欠落を修正

### DIFF
--- a/src/generator/highlight.ts
+++ b/src/generator/highlight.ts
@@ -7,6 +7,7 @@ import { config } from '../config'
 const HIGHLIGHT_WIDTH = 1080
 const HIGHLIGHT_HEIGHT = 1920
 const HIGHLIGHT_FPS = 30
+const MAX_HIGHLIGHT_SECONDS = 60
 
 export interface HighlightSegment {
   path: string
@@ -43,6 +44,44 @@ export function buildConcatListContent(segmentPaths: string[]): string {
   return `${lines.join('\n')}\n`
 }
 
+export function buildImageSegmentOutputOptions(
+  secondsPerImage: number
+): string[] {
+  return [
+    '-map 0:v:0',
+    '-map 1:a:0',
+    '-shortest',
+    `-t ${secondsPerImage}`,
+    '-pix_fmt yuv420p',
+    '-movflags +faststart',
+    `-r ${HIGHLIGHT_FPS}`,
+  ]
+}
+
+export function buildVideoSegmentOutputOptions(
+  hasSourceAudio: boolean
+): string[] {
+  return [
+    '-map 0:v:0',
+    hasSourceAudio ? '-map 0:a:0' : '-map 1:a:0',
+    '-shortest',
+    '-pix_fmt yuv420p',
+    '-movflags +faststart',
+    `-r ${HIGHLIGHT_FPS}`,
+  ]
+}
+
+export function buildFinalHighlightOutputOptions(): string[] {
+  return [
+    '-map 0:v:0',
+    '-map 0:a:0',
+    `-t ${MAX_HIGHLIGHT_SECONDS}`,
+    '-pix_fmt yuv420p',
+    '-movflags +faststart',
+    `-r ${HIGHLIGHT_FPS}`,
+  ]
+}
+
 function runFfmpegCommand(
   command: ffmpeg.FfmpegCommand,
   outputPath: string
@@ -71,6 +110,19 @@ function runFfmpegCommand(
   })
 }
 
+function detectAudioStream(inputPath: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    ffmpeg.ffprobe(inputPath, (error, metadata) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve(metadata.streams.some((stream) => stream.codec_type === 'audio'))
+    })
+  })
+}
+
 async function renderSegmentClip(
   segment: HighlightSegment,
   outputPath: string
@@ -79,20 +131,38 @@ async function renderSegmentClip(
 
   if (segment.type === 'image') {
     command = command
-      .inputOptions(['-loop 1', `-t ${config.processing.secondsPerImage}`])
+      .inputOptions(['-loop 1'])
+      .input('anullsrc=channel_layout=stereo:sample_rate=48000')
+      .inputFormat('lavfi')
       .videoFilters(buildImageSegmentFilters(config.processing.secondsPerImage))
-  } else {
-    command = command.videoFilters(buildVideoSegmentFilters())
+      .videoCodec('libx264')
+      .audioCodec('aac')
+      .audioFrequency(48000)
+      .audioChannels(2)
+      .outputOptions(
+        buildImageSegmentOutputOptions(config.processing.secondsPerImage)
+      )
+
+    await runFfmpegCommand(command, outputPath)
+    return
+  }
+
+  const hasSourceAudio = await detectAudioStream(segment.path)
+
+  command = command.videoFilters(buildVideoSegmentFilters())
+
+  if (!hasSourceAudio) {
+    command = command
+      .input('anullsrc=channel_layout=stereo:sample_rate=48000')
+      .inputFormat('lavfi')
   }
 
   command = command
     .videoCodec('libx264')
-    .outputOptions([
-      '-pix_fmt yuv420p',
-      '-movflags +faststart',
-      `-r ${HIGHLIGHT_FPS}`,
-      '-an',
-    ])
+    .audioCodec('aac')
+    .audioFrequency(48000)
+    .audioChannels(2)
+    .outputOptions(buildVideoSegmentOutputOptions(hasSourceAudio))
 
   await runFfmpegCommand(command, outputPath)
 }
@@ -112,20 +182,16 @@ async function concatSegmentClips(
       .input(listPath)
       .inputOptions(['-f concat', '-safe 0'])
       .videoCodec('libx264')
-      .outputOptions([
-        '-pix_fmt yuv420p',
-        '-movflags +faststart',
-        `-r ${HIGHLIGHT_FPS}`,
-      ])
+      .audioCodec('aac')
+      .audioFrequency(48000)
+      .audioChannels(2)
+      .outputOptions(buildFinalHighlightOutputOptions())
 
     if (config.bgmPath) {
       command = command
         .input(config.bgmPath)
         .audioCodec('aac')
         .audioBitrate('192k')
-        .outputOptions(['-map 0:v:0', '-map 1:a:0', '-shortest'])
-    } else {
-      command = command.outputOptions(['-map 0:v:0', '-an'])
     }
 
     await runFfmpegCommand(command, outputPath)

--- a/test/highlight.test.ts
+++ b/test/highlight.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'bun:test'
 import {
   buildConcatListContent,
+  buildFinalHighlightOutputOptions,
   buildImageSegmentFilters,
+  buildImageSegmentOutputOptions,
   buildVideoSegmentFilters,
+  buildVideoSegmentOutputOptions,
 } from '../src/generator/highlight'
 
 describe('buildImageSegmentFilters', () => {
@@ -26,6 +29,57 @@ describe('buildVideoSegmentFilters', () => {
       'setsar=1',
       'setpts=PTS-STARTPTS',
       'format=yuv420p',
+    ])
+  })
+})
+
+describe('buildImageSegmentOutputOptions', () => {
+  it('静止画セグメントに無音トラックと秒数制限を付ける', () => {
+    expect(buildImageSegmentOutputOptions(3)).toEqual([
+      '-map 0:v:0',
+      '-map 1:a:0',
+      '-shortest',
+      '-t 3',
+      '-pix_fmt yuv420p',
+      '-movflags +faststart',
+      '-r 30',
+    ])
+  })
+})
+
+describe('buildVideoSegmentOutputOptions', () => {
+  it('元動画に音声があればそれを使う', () => {
+    expect(buildVideoSegmentOutputOptions(true)).toEqual([
+      '-map 0:v:0',
+      '-map 0:a:0',
+      '-shortest',
+      '-pix_fmt yuv420p',
+      '-movflags +faststart',
+      '-r 30',
+    ])
+  })
+
+  it('元動画に音声がなければ無音トラックを使う', () => {
+    expect(buildVideoSegmentOutputOptions(false)).toEqual([
+      '-map 0:v:0',
+      '-map 1:a:0',
+      '-shortest',
+      '-pix_fmt yuv420p',
+      '-movflags +faststart',
+      '-r 30',
+    ])
+  })
+})
+
+describe('buildFinalHighlightOutputOptions', () => {
+  it('最終動画を 60 秒で打ち切る', () => {
+    expect(buildFinalHighlightOutputOptions()).toEqual([
+      '-map 0:v:0',
+      '-map 0:a:0',
+      '-t 60',
+      '-pix_fmt yuv420p',
+      '-movflags +faststart',
+      '-r 30',
     ])
   })
 })


### PR DESCRIPTION
## 概要
- 静止画が異常に長く伸びる問題を修正
- 元動画の音声が落ちる問題を修正
- ハイライト全体の長さをまず 60 秒に制限

## 原因
- 静止画セグメントで入力側に `-t` を付けていたため、`-loop 1` と組み合わせた時に意図より長く伸びるケースがあった
- セグメント生成時に常に `-an` を付けていたため、元動画由来の音声トラックが完全に捨てられていた
- 全セグメントをそのまま連結していたため、素材数が多い日ではハイライト全体が過剰に長くなっていた

## 改善内容
- 画像セグメントは入力側ではなく出力側で秒数制御するよう変更
- 各セグメントを video + audio 付き mp4 に正規化してから連結するよう変更
- 元動画に音声がある場合はその音声を保持
- 静止画と無音動画には無音トラックを付与
- 最終ハイライト動画は `-t 60` で打ち切るよう変更
- テストを追加して output option を検証

## 変更内容
- `buildImageSegmentOutputOptions` を追加し、静止画セグメントに秒数制限と無音トラックを付与
- `buildVideoSegmentOutputOptions` を追加し、元動画の音声有無に応じて map を切り替え
- `detectAudioStream` を追加し、素材動画に音声トラックがある場合だけ元音声を採用
- `buildFinalHighlightOutputOptions` を追加し、最終出力を 60 秒に制限
- テストを追加して output option を検証

## 確認
- `bun test`
- `bun run lint`
- `bun run format:check`
