### PR TITLE
Fix lavfi handling in highlight dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cp .env.example .env
 # 手動でハイライトを生成
 bun run generate
 
-# 実際には生成せず、集約対象・画像スコア・ffmpeg 実行予定だけ確認
+# 最終動画は生成せず、集約対象・画像スコア・ffmpeg 実行予定と ffmpeg 検証実行を確認
 bun run generate --dry-run
 
 # 指定した画像一覧だけでハイライトを生成

--- a/src/generator/highlight.ts
+++ b/src/generator/highlight.ts
@@ -1,8 +1,11 @@
-import ffmpeg from 'fluent-ffmpeg'
+import { execFile } from 'child_process'
 import { mkdtemp, rm, writeFile } from 'fs/promises'
 import os from 'os'
 import path from 'path'
+import { promisify } from 'util'
 import { config } from '../config'
+
+const execFileAsync = promisify(execFile)
 
 const HIGHLIGHT_WIDTH = 1080
 const HIGHLIGHT_HEIGHT = 1920
@@ -19,6 +22,10 @@ export interface HighlightCommandPreview {
   outputPath: string
   command: string
   kind: 'segment' | 'concat'
+}
+
+export interface HighlightDryRunResult {
+  commands: HighlightCommandPreview[]
 }
 
 export function buildImageSegmentFilters(secondsPerImage: number): string[] {
@@ -55,13 +62,19 @@ export function buildImageSegmentOutputOptions(
   secondsPerImage: number
 ): string[] {
   return [
-    '-map 0:v:0',
-    '-map 1:a:0',
+    '-map',
+    '0:v:0',
+    '-map',
+    '1:a:0',
     '-shortest',
-    `-t ${secondsPerImage}`,
-    '-pix_fmt yuv420p',
-    '-movflags +faststart',
-    `-r ${HIGHLIGHT_FPS}`,
+    '-t',
+    `${secondsPerImage}`,
+    '-pix_fmt',
+    'yuv420p',
+    '-movflags',
+    '+faststart',
+    '-r',
+    `${HIGHLIGHT_FPS}`,
   ]
 }
 
@@ -69,151 +82,209 @@ export function buildVideoSegmentOutputOptions(
   hasSourceAudio: boolean
 ): string[] {
   return [
-    '-map 0:v:0',
-    hasSourceAudio ? '-map 0:a:0' : '-map 1:a:0',
+    '-map',
+    '0:v:0',
+    '-map',
+    hasSourceAudio ? '0:a:0' : '1:a:0',
     '-shortest',
-    '-pix_fmt yuv420p',
-    '-movflags +faststart',
-    `-r ${HIGHLIGHT_FPS}`,
+    '-pix_fmt',
+    'yuv420p',
+    '-movflags',
+    '+faststart',
+    '-r',
+    `${HIGHLIGHT_FPS}`,
   ]
 }
 
 export function buildFinalHighlightOutputOptions(): string[] {
   return [
-    '-map 0:v:0',
-    '-map 0:a:0',
-    `-t ${MAX_HIGHLIGHT_SECONDS}`,
-    '-movflags +faststart',
+    '-map',
+    '0:v:0',
+    '-map',
+    '0:a:0',
+    '-t',
+    `${MAX_HIGHLIGHT_SECONDS}`,
+    '-movflags',
+    '+faststart',
   ]
 }
 
-function runFfmpegCommand(
-  command: ffmpeg.FfmpegCommand,
-  outputPath: string
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    command
-      .output(outputPath)
-      .on('start', (cmdLine) => console.log(`  ffmpeg: ${cmdLine}`))
-      .on('progress', (progress) => {
-        if (progress.percent) {
-          process.stdout.write(`\r  encoding: ${Math.round(progress.percent)}%`)
-        }
-      })
-      .on('end', () => {
-        console.log(`\n  ✅ saved: ${outputPath}`)
-        resolve()
-      })
-      .on('error', (error) => {
-        rm(outputPath, { force: true })
-          .catch(() => undefined)
-          .finally(() => {
-            reject(error)
-          })
-      })
-      .run()
-  })
+export function buildSilentAudioInputArgs(): string[] {
+  return [
+    '-f',
+    'lavfi',
+    '-i',
+    `anullsrc=channel_layout=stereo:sample_rate=${HIGHLIGHT_AUDIO_RATE}`,
+  ]
 }
 
-function getCommandArguments(command: ffmpeg.FfmpegCommand): string[] {
-  const fluentCommand = command as ffmpeg.FfmpegCommand & {
-    _getArguments(): string[]
+function quoteCommandArg(arg: string): string {
+  if (/^[A-Za-z0-9_./:=+-]+$/.test(arg)) {
+    return arg
   }
-  // eslint-disable-next-line no-underscore-dangle
-  return fluentCommand._getArguments()
+
+  return `'${arg.replace(/'/g, String.raw`'\''`)}'`
 }
 
-function buildCommandPreview(command: ffmpeg.FfmpegCommand): string {
-  return `ffmpeg ${getCommandArguments(command).join(' ')}`
+function buildCommandPreview(args: string[]): string {
+  return `ffmpeg ${args.map(quoteCommandArg).join(' ')}`
 }
 
-function detectAudioStream(inputPath: string): Promise<boolean> {
-  return new Promise((resolve, reject) => {
-    ffmpeg.ffprobe(inputPath, (error, metadata) => {
-      if (error) {
-        reject(error)
-        return
-      }
+async function runFfmpeg(args: string[], outputPath: string): Promise<void> {
+  console.log(`  ffmpeg: ${buildCommandPreview(args)}`)
 
-      resolve(metadata.streams.some((stream) => stream.codec_type === 'audio'))
+  try {
+    await execFileAsync('ffmpeg', args, {
+      maxBuffer: 1024 * 1024 * 50,
     })
-  })
+  } catch (error) {
+    if (outputPath !== '-') {
+      await rm(outputPath, { force: true }).catch(() => undefined)
+    }
+    throw error
+  }
+
+  if (outputPath !== '-') {
+    console.log(`  ✅ saved: ${outputPath}`)
+  }
 }
 
-function addSilentAudioInput(command: ffmpeg.FfmpegCommand) {
-  return command
-    .input(`anullsrc=channel_layout=stereo:sample_rate=${HIGHLIGHT_AUDIO_RATE}`)
-    .inputFormat('lavfi')
+async function detectAudioStream(inputPath: string): Promise<boolean> {
+  const { stdout } = await execFileAsync(
+    'ffprobe',
+    [
+      '-v',
+      'error',
+      '-select_streams',
+      'a',
+      '-show_entries',
+      'stream=codec_type',
+      '-of',
+      'default=noprint_wrappers=1:nokey=1',
+      inputPath,
+    ],
+    { maxBuffer: 1024 * 1024 * 10 }
+  )
+
+  return stdout
+    .split('\n')
+    .some((line) => line.trim().toLowerCase() === 'audio')
 }
 
-async function buildSegmentCommand(
-  segment: HighlightSegment
-): Promise<ffmpeg.FfmpegCommand> {
-  let command = ffmpeg().input(segment.path)
+async function buildSegmentArgs(
+  segment: HighlightSegment,
+  outputPath: string
+): Promise<string[]> {
+  const args = ['-hide_banner', '-loglevel', 'info', '-y']
 
   if (segment.type === 'image') {
-    return addSilentAudioInput(command.inputOptions(['-loop 1']))
-      .videoFilters(buildImageSegmentFilters(config.processing.secondsPerImage))
-      .videoCodec('libx264')
-      .audioCodec('aac')
-      .audioFrequency(HIGHLIGHT_AUDIO_RATE)
-      .audioChannels(2)
-      .outputOptions(
-        buildImageSegmentOutputOptions(config.processing.secondsPerImage)
-      )
+    args.push('-loop', '1', '-i', segment.path, ...buildSilentAudioInputArgs())
+    args.push(
+      '-vf',
+      buildImageSegmentFilters(config.processing.secondsPerImage).join(','),
+      '-c:v',
+      'libx264',
+      '-c:a',
+      'aac',
+      '-ar',
+      `${HIGHLIGHT_AUDIO_RATE}`,
+      '-ac',
+      '2',
+      ...buildImageSegmentOutputOptions(config.processing.secondsPerImage),
+      outputPath
+    )
+    return args
   }
 
   const hasSourceAudio = await detectAudioStream(segment.path)
-
-  command = command.videoFilters(buildVideoSegmentFilters())
-
+  args.push('-i', segment.path)
   if (!hasSourceAudio) {
-    command = addSilentAudioInput(command)
+    args.push(...buildSilentAudioInputArgs())
   }
 
-  return command
-    .videoCodec('libx264')
-    .audioCodec('aac')
-    .audioFrequency(HIGHLIGHT_AUDIO_RATE)
-    .audioChannels(2)
-    .outputOptions(buildVideoSegmentOutputOptions(hasSourceAudio))
+  args.push(
+    '-vf',
+    buildVideoSegmentFilters().join(','),
+    '-c:v',
+    'libx264',
+    '-c:a',
+    'aac',
+    '-ar',
+    `${HIGHLIGHT_AUDIO_RATE}`,
+    '-ac',
+    '2',
+    ...buildVideoSegmentOutputOptions(hasSourceAudio),
+    outputPath
+  )
+
+  return args
 }
 
-async function renderSegmentClip(
-  segment: HighlightSegment,
-  outputPath: string
-): Promise<void> {
-  const command = await buildSegmentCommand(segment)
-  await runFfmpegCommand(command, outputPath)
-}
-
-function buildConcatCommand(
-  segmentPaths: string[],
-  listPath: string
-): ffmpeg.FfmpegCommand {
-  let command = ffmpeg()
-    .input(listPath)
-    .inputOptions(['-f concat', '-safe 0'])
-    .outputOptions(buildFinalHighlightOutputOptions())
+function buildConcatArgs(
+  listPath: string,
+  outputPath: string,
+  dryRun: boolean
+): string[] {
+  const args = [
+    '-hide_banner',
+    '-loglevel',
+    'info',
+    '-y',
+    '-f',
+    'concat',
+    '-safe',
+    '0',
+    '-i',
+    listPath,
+  ]
 
   if (config.bgmPath) {
-    command = command
-      .input(config.bgmPath)
-      .complexFilter(['[0:a][1:a]amix=inputs=2:duration=first[aout]'])
-      .videoCodec('copy')
-      .audioCodec('aac')
-      .audioFrequency(HIGHLIGHT_AUDIO_RATE)
-      .audioChannels(2)
-      .outputOptions([
-        '-map 0:v:0',
-        '-map [aout]',
-        `-t ${MAX_HIGHLIGHT_SECONDS}`,
-      ])
-  } else {
-    command = command.outputOptions(['-c copy'])
+    args.push('-i', config.bgmPath)
+    args.push(
+      '-filter_complex',
+      '[0:a][1:a]amix=inputs=2:duration=first[aout]',
+      '-map',
+      '0:v:0',
+      '-map',
+      '[aout]',
+      '-c:v',
+      dryRun ? 'null' : 'copy',
+      '-c:a',
+      'aac',
+      '-ar',
+      `${HIGHLIGHT_AUDIO_RATE}`,
+      '-ac',
+      '2',
+      '-t',
+      `${MAX_HIGHLIGHT_SECONDS}`
+    )
+
+    if (dryRun) {
+      args.push('-f', 'null', outputPath)
+      return args
+    }
+
+    args.push('-movflags', '+faststart', outputPath)
+    return args
   }
 
-  return command
+  if (dryRun) {
+    args.push(
+      '-map',
+      '0:v:0',
+      '-map',
+      '0:a:0',
+      '-t',
+      `${MAX_HIGHLIGHT_SECONDS}`,
+      '-f',
+      'null',
+      outputPath
+    )
+    return args
+  }
+
+  args.push(...buildFinalHighlightOutputOptions(), '-c', 'copy', outputPath)
+  return args
 }
 
 async function concatSegmentClips(
@@ -225,10 +296,7 @@ async function concatSegmentClips(
   await writeFile(listPath, buildConcatListContent(segmentPaths), 'utf8')
 
   try {
-    await runFfmpegCommand(
-      buildConcatCommand(segmentPaths, listPath),
-      outputPath
-    )
+    await runFfmpeg(buildConcatArgs(listPath, outputPath, false), outputPath)
   } finally {
     await rm(listPath, { force: true })
   }
@@ -247,10 +315,9 @@ export async function buildHighlightCommandPreviews(
       tempDir,
       `segment-${String(index).padStart(4, '0')}.mp4`
     )
-    const command = await buildSegmentCommand(segment)
-    command.output(segmentOutputPath)
+    const args = await buildSegmentArgs(segment, segmentOutputPath)
     previews.push({
-      command: buildCommandPreview(command),
+      command: buildCommandPreview(args),
       kind: 'segment',
       outputPath: segmentOutputPath,
     })
@@ -258,15 +325,61 @@ export async function buildHighlightCommandPreviews(
   }
 
   const listPath = path.join(tempDir, 'concat-list.txt')
-  const concatCommand = buildConcatCommand(segmentPaths, listPath)
-  concatCommand.output(outputPath)
   previews.push({
-    command: buildCommandPreview(concatCommand),
+    command: buildCommandPreview(buildConcatArgs(listPath, outputPath, false)),
     kind: 'concat',
     outputPath,
   })
 
   return previews
+}
+
+export async function runHighlightDryRun(
+  segments: HighlightSegment[],
+  outputPath: string
+): Promise<HighlightDryRunResult> {
+  const tempDir = await mkdtemp(
+    path.join(os.tmpdir(), 'nas-photo-highlight-dry-run-')
+  )
+
+  try {
+    const commands: HighlightCommandPreview[] = []
+    const renderedSegmentPaths: string[] = []
+
+    for (const [index, segment] of segments.entries()) {
+      const segmentOutputPath = path.join(
+        tempDir,
+        `segment-${String(index).padStart(4, '0')}.mp4`
+      )
+      const args = await buildSegmentArgs(segment, segmentOutputPath)
+      commands.push({
+        command: buildCommandPreview(args),
+        kind: 'segment',
+        outputPath: segmentOutputPath,
+      })
+      await runFfmpeg(args, segmentOutputPath)
+      renderedSegmentPaths.push(segmentOutputPath)
+    }
+
+    const listPath = path.join(tempDir, 'concat-list.txt')
+    await writeFile(
+      listPath,
+      buildConcatListContent(renderedSegmentPaths),
+      'utf8'
+    )
+
+    const verifyArgs = buildConcatArgs(listPath, '-', true)
+    commands.push({
+      command: buildCommandPreview(verifyArgs),
+      kind: 'concat',
+      outputPath,
+    })
+    await runFfmpeg(verifyArgs, '-')
+
+    return { commands }
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
 }
 
 export async function generateHighlight(
@@ -285,7 +398,8 @@ export async function generateHighlight(
         tempDir,
         `segment-${String(index).padStart(4, '0')}.mp4`
       )
-      await renderSegmentClip(segment, segmentOutputPath)
+      const args = await buildSegmentArgs(segment, segmentOutputPath)
+      await runFfmpeg(args, segmentOutputPath)
       renderedSegmentPaths.push(segmentOutputPath)
     }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -6,6 +6,7 @@ import {
   buildHighlightCommandPreviews,
   generateHighlight,
   type HighlightCommandPreview,
+  runHighlightDryRun,
   type HighlightSegment,
 } from './generator/highlight'
 import { highlightDb } from './db/index'
@@ -126,6 +127,8 @@ function printDryRunGroup(group: DryRunHighlightGroup) {
 
   if (group.skipped) {
     console.log('  Result: skipped by existing output')
+  } else {
+    console.log('  Result: ffmpeg verification passed')
   }
 }
 
@@ -194,12 +197,17 @@ export async function runPipeline({
     )
 
     if (dryRun) {
-      const ffmpegCommands = await buildHighlightCommandPreviews(
+      const previewCommands = await buildHighlightCommandPreviews(
+        segments,
+        outputPath
+      )
+      const { commands: ffmpegCommands } = await runHighlightDryRun(
         segments,
         outputPath
       )
       printDryRunGroup({
-        ffmpegCommands,
+        ffmpegCommands:
+          ffmpegCommands.length > 0 ? ffmpegCommands : previewCommands,
         groupKey: key,
         imagePaths: bestImages,
         mediaPaths,

--- a/test/highlight.test.ts
+++ b/test/highlight.test.ts
@@ -4,6 +4,7 @@ import {
   buildFinalHighlightOutputOptions,
   buildImageSegmentFilters,
   buildImageSegmentOutputOptions,
+  buildSilentAudioInputArgs,
   buildVideoSegmentFilters,
   buildVideoSegmentOutputOptions,
 } from '../src/generator/highlight'
@@ -36,13 +37,19 @@ describe('buildVideoSegmentFilters', () => {
 describe('buildImageSegmentOutputOptions', () => {
   it('静止画セグメントに無音トラックと秒数制限を付ける', () => {
     expect(buildImageSegmentOutputOptions(3)).toEqual([
-      '-map 0:v:0',
-      '-map 1:a:0',
+      '-map',
+      '0:v:0',
+      '-map',
+      '1:a:0',
       '-shortest',
-      '-t 3',
-      '-pix_fmt yuv420p',
-      '-movflags +faststart',
-      '-r 30',
+      '-t',
+      '3',
+      '-pix_fmt',
+      'yuv420p',
+      '-movflags',
+      '+faststart',
+      '-r',
+      '30',
     ])
   })
 })
@@ -50,23 +57,33 @@ describe('buildImageSegmentOutputOptions', () => {
 describe('buildVideoSegmentOutputOptions', () => {
   it('元動画に音声があればそれを使う', () => {
     expect(buildVideoSegmentOutputOptions(true)).toEqual([
-      '-map 0:v:0',
-      '-map 0:a:0',
+      '-map',
+      '0:v:0',
+      '-map',
+      '0:a:0',
       '-shortest',
-      '-pix_fmt yuv420p',
-      '-movflags +faststart',
-      '-r 30',
+      '-pix_fmt',
+      'yuv420p',
+      '-movflags',
+      '+faststart',
+      '-r',
+      '30',
     ])
   })
 
   it('元動画に音声がなければ無音トラックを使う', () => {
     expect(buildVideoSegmentOutputOptions(false)).toEqual([
-      '-map 0:v:0',
-      '-map 1:a:0',
+      '-map',
+      '0:v:0',
+      '-map',
+      '1:a:0',
       '-shortest',
-      '-pix_fmt yuv420p',
-      '-movflags +faststart',
-      '-r 30',
+      '-pix_fmt',
+      'yuv420p',
+      '-movflags',
+      '+faststart',
+      '-r',
+      '30',
     ])
   })
 })
@@ -74,10 +91,25 @@ describe('buildVideoSegmentOutputOptions', () => {
 describe('buildFinalHighlightOutputOptions', () => {
   it('最終動画を 60 秒で打ち切る', () => {
     expect(buildFinalHighlightOutputOptions()).toEqual([
-      '-map 0:v:0',
-      '-map 0:a:0',
-      '-t 60',
-      '-movflags +faststart',
+      '-map',
+      '0:v:0',
+      '-map',
+      '0:a:0',
+      '-t',
+      '60',
+      '-movflags',
+      '+faststart',
+    ])
+  })
+})
+
+describe('buildSilentAudioInputArgs', () => {
+  it('lavfi を ffmpeg 引数として明示する', () => {
+    expect(buildSilentAudioInputArgs()).toEqual([
+      '-f',
+      'lavfi',
+      '-i',
+      'anullsrc=channel_layout=stereo:sample_rate=48000',
     ])
   })
 })


### PR DESCRIPTION
## 概要
- generate --dry-run の ffmpeg 検証実行を real ffmpeg ベースに切り替え
- lavfi の無音入力を fluent-ffmpeg 経由ではなく -f lavfi -i anullsrc=... で明示
- セグメント生成と concat 検証のコマンド表示も実行内容と一致するよう整理

## 原因
- anullsrc=... を fluent-ffmpeg の input() に文字列で渡すと、ライブラリ内部でファイル入力として扱われる
- その後に inputFormat(lavfi) を付けても事前チェック側の分類は変わらず、lavfi 入力の前段で失敗する
- そのため dry-run 時点で ffmpeg の検証に入れず、切り分け用途として機能していなかった

## 対応
- highlight generator を raw ffmpeg 引数ベースに変更
- 静止画と無音動画で使う無音トラック入力を -f lavfi -i anullsrc=... で直接構築
- dry-run ではセグメントを一時 mp4 に正規化した上で、concat を -f null - へ流して実検証する形に変更
- テストに lavfi 引数の組み立て確認を追加

## 確認
- bun test
- bun run lint
- bun run format:check