### PR TITLE
generate に日付レンジ指定を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ bun run generate
 # 最終動画は生成せず、集約対象・画像スコア・ffmpeg 実行予定と ffmpeg 検証実行を確認
 bun run generate --dry-run
 
+# 日付レンジを指定して対象を絞り込む
+bun run generate --run-now --from 2026-03-01 --to 2026-03-07
+
+# input-list と併用して、さらに日付レンジで絞り込む
+bun run generate --run-now --input-list /path/to/input-files.txt --from 2026-03-01
+
 # 指定した画像一覧だけでハイライトを生成
 bun run generate --input-list /path/to/input-files.txt
 

--- a/src/cli/generateOptions.ts
+++ b/src/cli/generateOptions.ts
@@ -1,0 +1,52 @@
+export interface GenerateOptions {
+  dateFrom?: string
+  dateTo?: string
+  dryRun: boolean
+  force: boolean
+  inputListPath?: string
+  notify: boolean
+  runNow: boolean
+}
+
+function validateDateArg(flag: '--from' | '--to', value?: string) {
+  if (!value) {
+    throw new Error(`${flag} requires a YYYY-MM-DD value`)
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`${flag} must be in YYYY-MM-DD format`)
+  }
+}
+
+export function parseGenerateOptions(args: string[]): GenerateOptions {
+  const inputListIndex = args.indexOf('--input-list')
+  const inputListPath =
+    inputListIndex >= 0 ? args[inputListIndex + 1] : undefined
+  const fromIndex = args.indexOf('--from')
+  const dateFrom = fromIndex >= 0 ? args[fromIndex + 1] : undefined
+  const toIndex = args.indexOf('--to')
+  const dateTo = toIndex >= 0 ? args[toIndex + 1] : undefined
+
+  if (inputListIndex >= 0 && !inputListPath) {
+    throw new Error(
+      'Usage: bun run generate --input-list /path/to/input-files.txt'
+    )
+  }
+
+  if (fromIndex >= 0) validateDateArg('--from', dateFrom)
+  if (toIndex >= 0) validateDateArg('--to', dateTo)
+
+  if (dateFrom && dateTo && dateFrom > dateTo) {
+    throw new Error('--from must be earlier than or equal to --to')
+  }
+
+  return {
+    dateFrom,
+    dateTo,
+    dryRun: args.includes('--dry-run'),
+    force: args.includes('--force'),
+    inputListPath,
+    notify: args.includes('--notify'),
+    runNow: args.includes('--run-now'),
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,28 +4,23 @@ import { runPipeline } from './pipeline'
 import { startWebServer } from './server'
 import { notifyLatestRun, sendNotification } from './notify'
 import { resolveOutputPath } from './outputPath'
+import { parseGenerateOptions } from './cli/generateOptions'
 
 validateConfig()
 
-const args = process.argv.slice(2)
-const inputListIndex = args.indexOf('--input-list')
-const inputListPath = inputListIndex >= 0 ? args[inputListIndex + 1] : undefined
+const options = parseGenerateOptions(process.argv.slice(2))
 
-if (inputListIndex >= 0 && !inputListPath) {
-  throw new Error(
-    'Usage: bun run generate --input-list /path/to/input-files.txt'
-  )
-}
-
-if (args.includes('--run-now')) {
+if (options.runNow) {
   // One-shot: process immediately and exit
   await runPipeline({
-    dryRun: args.includes('--dry-run'),
-    force: args.includes('--force'),
-    inputListPath,
+    dateFrom: options.dateFrom,
+    dateTo: options.dateTo,
+    dryRun: options.dryRun,
+    force: options.force,
+    inputListPath: options.inputListPath,
   })
   process.exit(0)
-} else if (args.includes('--notify')) {
+} else if (options.notify) {
   await notifyLatestRun(resolveOutputPath(config.nas.metaOutputPath))
   console.log('🔔 Notification sent')
   process.exit(0)

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,6 +1,11 @@
 import path from 'path'
 import { writeFileSync } from 'fs'
-import { groupImages, isImagePath, isVideoPath } from './scanner/grouper'
+import {
+  groupImages,
+  isImagePath,
+  isVideoPath,
+  type MediaDateRange,
+} from './scanner/grouper'
 import { scoreImages } from './scorer/imageScore'
 import {
   buildHighlightCommandPreviews,
@@ -90,6 +95,20 @@ export function shouldSkipHighlightGeneration({
   return existingOutputPath === targetOutputPath
 }
 
+export function normalizeDateRange({
+  dateFrom,
+  dateTo,
+}: MediaDateRange): MediaDateRange | undefined {
+  if (!dateFrom && !dateTo) {
+    return undefined
+  }
+
+  return {
+    dateFrom,
+    dateTo,
+  }
+}
+
 interface DryRunHighlightGroup {
   groupKey: string
   imagePaths: string[]
@@ -136,10 +155,14 @@ export async function runPipeline({
   force = false,
   dryRun = false,
   inputListPath,
+  dateFrom,
+  dateTo,
 }: {
   force?: boolean
   dryRun?: boolean
   inputListPath?: string
+  dateFrom?: string
+  dateTo?: string
 } = {}): Promise<PipelineRunSummary> {
   console.log('🔍 Scanning media...')
   const resolvedMetaOutputPath = resolveOutputPath(config.nas.metaOutputPath)
@@ -147,7 +170,11 @@ export async function runPipeline({
   prepareMetaOutputPath(resolvedMetaOutputPath)
   prepareOutputPath(resolvedOutputPath)
 
-  const groups = await groupImages(inputListPath)
+  const dateRange = normalizeDateRange({ dateFrom, dateTo })
+  const groups = await groupImages({
+    inputListPath,
+    ...dateRange,
+  })
   console.log(`📁 Found ${groups.size} groups`)
 
   let generated = 0

--- a/src/scanner/grouper.ts
+++ b/src/scanner/grouper.ts
@@ -4,6 +4,10 @@ import exifr from 'exifr'
 import { config } from '../config'
 
 export type ImageGroup = Map<string, string[]>
+export interface MediaDateRange {
+  dateFrom?: string
+  dateTo?: string
+}
 
 const IMAGE_EXTS = new Set(['.jpg', '.jpeg', '.png', '.heic', '.webp'])
 const VIDEO_EXTS = new Set([
@@ -76,6 +80,32 @@ async function getDateKey(mediaPath: string): Promise<string> {
   return mtime.toISOString().slice(0, 10)
 }
 
+export async function filterMediaByDateRange(
+  mediaPaths: string[],
+  range: MediaDateRange,
+  getDateKeyFn: (mediaPath: string) => Promise<string> = getDateKey
+): Promise<string[]> {
+  if (!range.dateFrom && !range.dateTo) {
+    return mediaPaths
+  }
+
+  const filtered: string[] = []
+  for (const mediaPath of mediaPaths) {
+    const dateKey = await getDateKeyFn(mediaPath)
+    if (range.dateFrom && dateKey < range.dateFrom) {
+      continue
+    }
+
+    if (range.dateTo && dateKey > range.dateTo) {
+      continue
+    }
+
+    filtered.push(mediaPath)
+  }
+
+  return filtered
+}
+
 async function sortGroupMedia(
   mediaPaths: string[],
   getCapturedAtFn: (mediaPath: string) => Promise<Date>
@@ -139,20 +169,28 @@ export async function groupListedImages(
  * Group supported media under NAS_PHOTO_PATH by date (YYYY-MM-DD) or by subfolder.
  * Returns a Map of groupKey → [mediaPaths]
  */
-export async function groupImages(inputListPath?: string): Promise<ImageGroup> {
+export async function groupImages({
+  inputListPath,
+  dateFrom,
+  dateTo,
+}: MediaDateRange & { inputListPath?: string } = {}): Promise<ImageGroup> {
   const allMedia = inputListPath
     ? readInputList(inputListPath)
     : collectMedia(config.nas.photoPath)
+  const filteredMedia = await filterMediaByDateRange(allMedia, {
+    dateFrom,
+    dateTo,
+  })
 
   if (inputListPath) {
     console.log(
-      `Found ${allMedia.length} media files in input list ${inputListPath}`
+      `Found ${filteredMedia.length} media files in input list ${inputListPath}`
     )
   } else {
     console.log(
-      `Found ${allMedia.length} media files in ${config.nas.photoPath}`
+      `Found ${filteredMedia.length} media files in ${config.nas.photoPath}`
     )
   }
 
-  return groupListedMedia(allMedia, config.processing.groupBy)
+  return groupListedMedia(filteredMedia, config.processing.groupBy)
 }

--- a/test/generateOptions.test.ts
+++ b/test/generateOptions.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test'
+import { parseGenerateOptions } from '../src/cli/generateOptions'
+
+describe('parseGenerateOptions', () => {
+  it('from と to を含む generate 引数を解釈する', () => {
+    expect(
+      parseGenerateOptions([
+        '--run-now',
+        '--dry-run',
+        '--force',
+        '--from',
+        '2026-03-01',
+        '--to',
+        '2026-03-07',
+      ])
+    ).toEqual({
+      dateFrom: '2026-03-01',
+      dateTo: '2026-03-07',
+      dryRun: true,
+      force: true,
+      inputListPath: undefined,
+      notify: false,
+      runNow: true,
+    })
+  })
+
+  it('日付形式が不正なら失敗する', () => {
+    expect(() => parseGenerateOptions(['--from', '2026/03/01'])).toThrow(
+      '--from must be in YYYY-MM-DD format'
+    )
+    expect(() => parseGenerateOptions(['--to', '03-07-2026'])).toThrow(
+      '--to must be in YYYY-MM-DD format'
+    )
+  })
+
+  it('from が to より後なら失敗する', () => {
+    expect(() =>
+      parseGenerateOptions(['--from', '2026-03-08', '--to', '2026-03-07'])
+    ).toThrow('--from must be earlier than or equal to --to')
+  })
+
+  it('input-list も併用できる', () => {
+    expect(
+      parseGenerateOptions([
+        '--run-now',
+        '--input-list',
+        '/tmp/input-list.txt',
+        '--from',
+        '2026-03-01',
+      ])
+    ).toEqual({
+      dateFrom: '2026-03-01',
+      dateTo: undefined,
+      dryRun: false,
+      force: false,
+      inputListPath: '/tmp/input-list.txt',
+      notify: false,
+      runNow: true,
+    })
+  })
+})

--- a/test/grouper.test.ts
+++ b/test/grouper.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import os from 'os'
 import path from 'path'
 import {
+  filterMediaByDateRange,
   groupListedMedia,
   groupListedImages,
   isImagePath,
@@ -113,6 +114,30 @@ describe('groupListedImages', () => {
       '/Volumes/photo/trip/a.jpg',
       '/Volumes/photo/trip/c.mov',
       '/Volumes/photo/trip/b.jpg',
+    ])
+  })
+
+  it('日付レンジでメディアを絞り込める', async () => {
+    const result = await filterMediaByDateRange(
+      [
+        '/Volumes/photo/trip/a.jpg',
+        '/Volumes/photo/trip/b.jpg',
+        '/Volumes/photo/trip/c.mov',
+      ],
+      {
+        dateFrom: '2026-03-02',
+        dateTo: '2026-03-03',
+      },
+      async (mediaPath) => {
+        if (mediaPath.endsWith('a.jpg')) return '2026-03-01'
+        if (mediaPath.endsWith('b.jpg')) return '2026-03-02'
+        return '2026-03-03'
+      }
+    )
+
+    expect(result).toEqual([
+      '/Volumes/photo/trip/b.jpg',
+      '/Volumes/photo/trip/c.mov',
     ])
   })
 })

--- a/test/highlight.integration.test.ts
+++ b/test/highlight.integration.test.ts
@@ -9,6 +9,7 @@ import {
   readFile,
   rm,
   stat,
+  utimes,
   writeFile,
 } from 'fs/promises'
 import path from 'path'
@@ -316,6 +317,21 @@ describe('highlight integration', () => {
         await writeFile(fakeHeicPath, await readFile(imageBPath))
         await writeFile(brokenVideoPath, 'not-an-mp4', 'utf8')
         await writeFile(faceAnalysisPath, '{}', 'utf8')
+        await utimes(
+          imageAPath,
+          new Date('2026-03-01T09:00:00.000Z'),
+          new Date('2026-03-01T09:00:00.000Z')
+        )
+        await utimes(
+          fakeHeicPath,
+          new Date('2026-03-02T09:00:00.000Z'),
+          new Date('2026-03-02T09:00:00.000Z')
+        )
+        await utimes(
+          audioVideoPath,
+          new Date('2026-03-03T09:00:00.000Z'),
+          new Date('2026-03-03T09:00:00.000Z')
+        )
 
         const mixedOutputPath = path.join(workDir, 'highlight-mixed.mp4')
         const silentOutputPath = path.join(workDir, 'highlight-silent.mp4')
@@ -406,8 +422,15 @@ describe('highlight integration', () => {
 
         const commonEnv = {
           ...process.env,
+          NAS_META_OUTPUT_PATH: metaDir,
+          NAS_OUTPUT_PATH: outputDir,
+          NAS_PHOTO_PATH: workDir,
           FFMPEG_BIN: mediaEnv.ffmpegBin,
           FFPROBE_BIN: mediaEnv.ffprobeBin,
+          GROUP_BY: 'date',
+          IMAGES_PER_HIGHLIGHT: String(processingConfig.imagesPerHighlight),
+          MIN_IMAGES_TO_GENERATE: String(processingConfig.minImagesToGenerate),
+          SECONDS_PER_IMAGE: String(processingConfig.secondsPerImage),
           NODE_ENV: 'test',
           TMPDIR: workDir,
         }
@@ -489,6 +512,23 @@ describe('highlight integration', () => {
           inputListPath,
         })
         expect(pipelineSummary.generated).toBe(0)
+
+        const cliGenerate = await runBunScript(
+          [
+            'src/index.ts',
+            '--run-now',
+            '--dry-run',
+            '--from',
+            '2026-03-02',
+            '--to',
+            '2026-03-02',
+          ],
+          commonEnv
+        )
+        expect(cliGenerate.stdout).toContain('Media (1):')
+        expect(cliGenerate.stdout).toContain(fakeHeicPath)
+        expect(cliGenerate.stdout).not.toContain(imageAPath)
+        expect(cliGenerate.stdout).not.toContain(audioVideoPath)
 
         const generatedFiles = await readdir(outputDir)
         expect(generatedFiles.some((file) => file.endsWith('.mp4'))).toBe(false)

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   buildHighlightSegments,
   buildManifestHighlight,
+  normalizeDateRange,
   shouldSkipHighlightGeneration,
 } from '../src/pipeline'
 
@@ -89,5 +90,23 @@ describe('buildHighlightSegments', () => {
       { path: '/Volumes/home/Photos/2026/03/c.jpg', type: 'image' },
       { path: '/Volumes/home/Photos/2026/03/d.mp4', type: 'video' },
     ])
+  })
+})
+
+describe('normalizeDateRange', () => {
+  it('from/to があれば date range オブジェクトを返す', () => {
+    expect(
+      normalizeDateRange({
+        dateFrom: '2026-03-01',
+        dateTo: '2026-03-07',
+      })
+    ).toEqual({
+      dateFrom: '2026-03-01',
+      dateTo: '2026-03-07',
+    })
+  })
+
+  it('どちらも無ければ undefined を返す', () => {
+    expect(normalizeDateRange({})).toBeUndefined()
   })
 })


### PR DESCRIPTION
## 概要
- generate に --from / --to を追加し、手で input list を作らず対象メディアを絞り込めるようにしました
- --input-list と併用でき、列挙後に date range で再度フィルタします
- TDD で単体テストを追加し、CLI の --run-now --dry-run --from/--to まで統合テストで通しています

## 変更内容
- src/cli/generateOptions.ts を追加して generate 用 CLI オプション解析を共通化
- groupImages に日付レンジ絞り込みを追加
- runPipeline に date range を渡せるように変更
- README に date range 利用例を追記
- grouper / pipeline / generate options の単体テストを追加
- index.ts --run-now --dry-run --from/--to の統合テストを追加

## 確認
- bun test
- bun run lint
- bun run format:check
