### PR TITLE
生成済みハイライトの自己混入をスキャナで除外する

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ src/
 |---|---|---|
 | `NAS_PHOTO_PATH` | — | マウント済み NAS 上の写真ディレクトリ |
 | `NAS_META_OUTPUT_PATH` | `NAS_OUTPUT_PATH` | `index.html` / `highlights.json` / `last-run.json` の出力先パス |
-| `NAS_OUTPUT_PATH` | — | ハイライト `.mp4` の出力先パス。`{yyyy}` / `{mm}` を利用可能 |
+| `NAS_OUTPUT_PATH` | — | ハイライト `.mp4` の出力先パス。`{yyyy}` / `{mm}` を利用可能。`NAS_PHOTO_PATH` 配下は避ける |
 | `GROUP_BY` | `date` | `date` または `folder` |
 | `IMAGES_PER_HIGHLIGHT` | `25` | 1 ハイライトあたりの最大ベストショット数 |
 | `SECONDS_PER_IMAGE` | `3` | 画像 1 枚あたりの表示秒数 |
@@ -165,6 +165,7 @@ src/
 注意:
 
 - `NAS_PHOTO_PATH` / `NAS_META_OUTPUT_PATH` / `NAS_OUTPUT_PATH` はローカル Mac の SMB マウントパスです
+- `NAS_OUTPUT_PATH` は `NAS_PHOTO_PATH` 配下に置かないでください。現在は `*_highlight.mp4` / `*_highlight_thumb.jpg` をスキャン除外していますが、出力先を分離しておく方が安全です
 - Docker bind mount には使えないので、NAS 側の実パスは `NAS_DEPLOY_META_PATH` / `NAS_DEPLOY_MEDIA_PATH` で別に指定します
 - まず `bun run deploy:nas:dry-run` で実行予定コマンドを確認してください
 

--- a/src/scanner/grouper.ts
+++ b/src/scanner/grouper.ts
@@ -32,6 +32,14 @@ function isSupportedMedia(file: string): boolean {
   return isImagePath(file) || isVideoPath(file)
 }
 
+function isGeneratedArtifactPath(file: string): boolean {
+  const normalized = path.basename(file).toLowerCase()
+  return (
+    normalized.endsWith('_highlight.mp4') ||
+    normalized.endsWith('_highlight_thumb.jpg')
+  )
+}
+
 export function readInputList(inputListPath: string): string[] {
   return readFileSync(inputListPath, 'utf8')
     .split('\n')
@@ -40,13 +48,17 @@ export function readInputList(inputListPath: string): string[] {
 }
 
 /** Recursively collect all supported media paths under a directory */
-function collectMedia(dir: string): string[] {
+export function collectMedia(dir: string): string[] {
   const results: string[] = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name)
     if (entry.isDirectory()) {
       results.push(...collectMedia(full))
-    } else if (entry.isFile() && isSupportedMedia(entry.name)) {
+    } else if (
+      entry.isFile() &&
+      isSupportedMedia(entry.name) &&
+      !isGeneratedArtifactPath(entry.name)
+    ) {
       results.push(full)
     }
   }

--- a/test/grouper.test.ts
+++ b/test/grouper.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import os from 'os'
 import path from 'path'
 import {
+  collectMedia,
   filterMediaByDateRange,
   groupListedMedia,
   groupListedImages,
@@ -139,5 +140,35 @@ describe('groupListedImages', () => {
       '/Volumes/photo/trip/b.jpg',
       '/Volumes/photo/trip/c.mov',
     ])
+  })
+})
+
+describe('collectMedia', () => {
+  it('生成済みハイライト動画とサムネイルを入力スキャンから除外する', () => {
+    const dir = makeDir()
+    const originalsDir = path.join(dir, '2026', '03')
+    mkdirSync(originalsDir, { recursive: true })
+
+    const originalImage = path.join(originalsDir, 'IMG_0001.JPG')
+    const originalVideo = path.join(originalsDir, 'IMG_0002.MOV')
+    const generatedHighlight = path.join(
+      originalsDir,
+      '2026-03-21_highlight.mp4'
+    )
+    const generatedThumbnail = path.join(
+      originalsDir,
+      '2026-03-21_highlight_thumb.jpg'
+    )
+
+    for (const filePath of [
+      originalImage,
+      originalVideo,
+      generatedHighlight,
+      generatedThumbnail,
+    ]) {
+      writeFileSync(filePath, '')
+    }
+
+    expect(collectMedia(dir)).toEqual([originalImage, originalVideo])
   })
 })


### PR DESCRIPTION
## 概要
- 再帰スキャン時に生成済みハイライト動画とサムネイルを除外
- 入力ツリー配下に生成物があるケースを再現する回帰テストを追加
- NAS_OUTPUT_PATH を NAS_PHOTO_PATH 配下に置かない運用注意を README に追記

## テスト
- bun test

Closes #24